### PR TITLE
Destroy knex connection pool when the server shuts down.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,14 @@ exports.register = function (server, options, next) {
 
     server.expose(bookshelf);
 
+    server.ext({
+      type: 'onPostStop',
+      method: function (server, next) {
+
+        bookshelf.knex.destroy(next);
+      }
+    });
+
     next();
 };
 


### PR DESCRIPTION
When the hapi server shuts down, i.e. when the onPostStop server
extension point is called we tear down knex's connection pool.

Otherwise, when a hapi server is stopped using `server.stop()`, the connection pool is still alive and the node.js program does not stop.
